### PR TITLE
resampleVolume accepts BakingTray data

### DIFF
--- a/code/utils/resampleVolume.m
+++ b/code/utils/resampleVolume.m
@@ -125,18 +125,23 @@ end
 
 %Create file name
 paramFile=getTiledAcquisitionParamFile;
-%TODO: the following will fail with BakingTray Data
-downsampledFname = [regexprep(paramFile(1:end-4),'Mosaic_','ds')];
+if startsWith(paramFile, 'recipe')
+    % We have BakingTray Data
+    downsampledFname = strcat('ds', paramFile(8:end-4));
+else
+    % We have TissueVision
+    downsampledFname = [regexprep(paramFile(1:end-4),'Mosaic_','ds')];
+end
 if mod(targetDims(1),1)==0
     downsampledFname=[downsampledFname, sprintf('_%d',targetDims(1))];
-  else
+else
     downsampledFname=[downsampledFname, sprintf('_%0.1f',targetDims(1))];
 end
 
 if mod(targetDims(2),1)==0
     downsampledFname=[downsampledFname, sprintf('_%d',targetDims(2))];
-  else
-    downsampledFname=[downsampledFname, sprintf('_%0.1f',targetDims(2))];    
+else
+    downsampledFname=[downsampledFname, sprintf('_%0.1f',targetDims(2))];
 end
 
 downsampledFname=[downsampledFname, sprintf('_%02d',channel)];


### PR DESCRIPTION
resampleVolume was failing if the file name does not contain `Mosaic_`
Now include a case for files starting by `recipe_` which seems to be
BakingTray default output