### PR TITLE
Use stitchingParams.ini instead of stitchitConf.ini

### DIFF
--- a/code/utils/resampleVolume.m
+++ b/code/utils/resampleVolume.m
@@ -85,7 +85,14 @@ if length(targetDims) ~= 2
 end
 
 %Calculate the original image size
-params=readStitchItINI;
+% Look first for a `stitchingParams.ini` in the data folder. If absent look
+% for default values
+if exist(fullfile(origDataDir, 'stitchingParams.ini'), 'file')
+    path2StitchInit = fullfile(origDataDir, 'stitchingParams.ini');
+else
+    path2StitchInit = [];
+end
+params=readStitchItINI(path2StitchInit);
 M=readMetaData2Stitchit;
 z=M.voxelSize.Z;
 


### PR DESCRIPTION
Before looking for default stitchitConf.ini, look in the data directory for a stitchingParams.ini and use that if it exists.

It seems to make sense to use the file found with the data rather than looking for a system defined conf but I don't know the whole pipeline or if you want to edit the stitchit before downsampling. 