### PR TITLE
Do not read stitch it ini to resample

### DIFF
--- a/code/utils/resampleVolume.m
+++ b/code/utils/resampleVolume.m
@@ -86,7 +86,6 @@ if length(targetDims) ~= 2
 end
 
 %Calculate the original image size
-params=readStitchItINI;
 M=readMetaData2Stitchit;
 z=M.voxelSize.Z;
 


### PR DESCRIPTION
The resampling function was loading stitchIt information from the ini file. It does not need it and might crash on ill-configured system. Remove that step.