### PR TITLE
Load existing statsTile

### DIFF
--- a/code/preProcessTiles/preProcessTiles.m
+++ b/code/preProcessTiles/preProcessTiles.m
@@ -242,6 +242,7 @@ for thisDir = 1:length(sectionDirectories)
     %Write tile statistics to a file. 
     if exist(statsFile,'file') && length(sectionsToProcess)==1 && sectionsToProcess==0 %Skip if sectionsToProcess is zero and file exists
         fprintf('%s stats file already exists\n',sectionDirectories(thisDir).name)
+        load(statsFile);
     else
         % Write tile statistics to disk. This can later be used to quickly calculate things like the intensity of
         % the backround tiles. If the offset subtraction was requested in the INI file (for non TV data) then we 


### PR DESCRIPTION
In the unlikely case where `tileStats.mat` is already generated but `preProcessTiles` still needs to do something (basically if it failed or if you have deleted to `averageDir` manually), the `statsFile` need to be read from disk (for now the code was just contemplating the fact that it existed and kept on to fail a bit further).