### PR TITLE
Fix issue # 80

### DIFF
--- a/code/preProcessTiles/private/calcAverageMatFiles.m
+++ b/code/preProcessTiles/private/calcAverageMatFiles.m
@@ -73,6 +73,12 @@ function calcAverageMatFiles(imStack,tileIndex,thisDirName,illumChans,tileStats)
             fprintf('%s: removed %d%% of tiles from illumination correction. SKIPPING.\n', ...
                 mfilename, round(propRemoved*100))
             continue
+        elseif all(mod(row,2))
+            fprintf('Only uneven rows left for illumination correction. SKIPPING.\n')
+            continue
+        elseif all(~mod(row,2))
+            fprintf('Only even rows left for illumination correction. SKIPPING.\n')
+            continue
         end
 
         row(lowVals)=[];


### PR DESCRIPTION
Simply skip combination for which there are only even or uneven rows. That should happen only if there are few tiles left anyway.