### PR TITLE
Make a tileStats per channel

### DIFF
--- a/code/+stitchit/+tools/getTileMaxValues.m
+++ b/code/+stitchit/+tools/getTileMaxValues.m
@@ -1,8 +1,10 @@
-function maxVals = getTileMaxValues(IN,chan,depth,n)
+function maxVals = getTileMaxValues(IN,depth,n)
 
-% Loop through output of stitchit.tools.loadAllTileStatsFiles and get the n largest means for the defined chan/depth combo
+% Loop through output of stitchit.tools.loadAllTileStatsFiles and get the n 
+% largest means for the defined depth for chan in IN (default 2, defined in
+% loadAllTilesStatsFiles)
 %
-% function maxVals = getTileMaxValues(IN,chan,depth,n)
+% function maxVals = getTileMaxValues(IN,depth,n)
 %
 %
 % Purpose
@@ -10,7 +12,6 @@ function maxVals = getTileMaxValues(IN,chan,depth,n)
 %
 % Inputs
 % IN - output of loadAllTileStatsFiles
-% chan - 2 by default
 % depth - 1 by default
 % n - 10 by default
 %
@@ -22,11 +23,7 @@ function maxVals = getTileMaxValues(IN,chan,depth,n)
 % Rob Campbell - Basel 2016
 
 
-if nargin<2 || isempty(chan)
-    chan=2;
-end
-
-if nargin<3 || isempty(depth)
+if nargin<2 || isempty(depth)
     depth=1;
 end
 
@@ -41,7 +38,7 @@ maxVals = zeros(length(IN),n);
 
 
 for ii=1:length(IN)
-    m=sort(IN(ii).mu{chan,depth},'descend');
+    m=sort(IN(ii).mu{1,depth},'descend');
     maxVals(ii,:) = m(1:n);
 end
 

--- a/code/+stitchit/+tools/loadAllTileStatsFiles.m
+++ b/code/+stitchit/+tools/loadAllTileStatsFiles.m
@@ -1,4 +1,4 @@
-function TILESTATS = loadAllTileStatsFiles
+function TILESTATS = loadAllTileStatsFiles(chan)
 
 % Loads all tile stats files .mat files
 %
@@ -7,6 +7,8 @@ function TILESTATS = loadAllTileStatsFiles
 % Purpose
 % Load all tileStats.mat files in the raw data directory and return as a structure
 % 
+% Inputs
+% chan - channel to load. Default 2
 %
 % Outputs
 % tileStats - vector all tileStats structures
@@ -14,7 +16,9 @@ function TILESTATS = loadAllTileStatsFiles
 %
 % Rob Campbell - Basel 2016
 
-error('Not Implemented. TileStats has been updated. Is this function ever used?')
+if ~exist('chan', 'var') || isempty(chan)
+    chan = 2;
+end
 
 %Load ini file variables
 userConfig=readStitchItINI;
@@ -36,7 +40,8 @@ fprintf('Loading tileStats.')
 for ii=1:length(D)
     if mod(ii,5)==0, fprintf('.'), end
 
-    fname = fullfile(userConfig.subdir.rawDataDir,D(ii).name,'tileStats.mat');
+    fname = fullfile(userConfig.subdir.rawDataDir, userConfig.subdir.preProcessDir, ...
+        D(ii).name,sprintf('tileStats_ch%.0f.mat', chan));
     if ~exist(fname,'file') %Skip this directory if no tileStats.mat file is present and increment counter
         numMissingFiles=numMissingFiles+1;
         continue

--- a/code/+stitchit/+tools/loadAllTileStatsFiles.m
+++ b/code/+stitchit/+tools/loadAllTileStatsFiles.m
@@ -14,6 +14,7 @@ function TILESTATS = loadAllTileStatsFiles
 %
 % Rob Campbell - Basel 2016
 
+error('Not Implemented. TileStats has been updated. Is this function ever used?')
 
 %Load ini file variables
 userConfig=readStitchItINI;

--- a/code/SystemClasses/@bakingtray/tileLoad.m
+++ b/code/SystemClasses/@bakingtray/tileLoad.m
@@ -182,10 +182,10 @@ end
 % is useful in the event that a drifting offset is creating problems. 
 % Can be used to deal with offset amplifiers for a wider dynamic range.
 if doSubtractOffset
-    tileStatsFname = fullfile(sectionDir,'tileStats.mat');
+    tileStatsFname = fullfile(sectionDir, sprintf('tileStats_ch%.0f.mat', channel));
     if exist(tileStatsFname,'file')
         load(tileStatsFname)
-        offsetMu = mean(tileStats.offsetMean(channel,:)); %since all depths will have the same underlying value
+        offsetMu = mean(tileStats.offsetMean(:)); %since all depths will have the same underlying value
         im = im - cast(offsetMu,class(im));
     else
         fprintf('bakingtray.tileLoad attempted to perform an offset correction but can not find file %s\n', tileStatsFname);

--- a/code/SystemClasses/@bakingtray/tileLoad.m
+++ b/code/SystemClasses/@bakingtray/tileLoad.m
@@ -33,7 +33,8 @@ end
 %Exit gracefully if data directory is missing 
 param = readMetaData2Stitchit;
 sectionDir=fullfile(userConfig.subdir.rawDataDir, sprintf('%s-%04d',param.sample.ID,coords(1)));
-sectionProcessDir=fullfile(userConfig.subdir.preProcessDir, sprintf('%s-%04d',param.sample.ID,coords(1)));
+sectionProcessDir=fullfile(userConfig.subdir.rawDataDir, userConfig.subdir.preProcessDir, ...
+    sprintf('%s-%04d',param.sample.ID,coords(1)));
 
 if ~exist(sectionDir,'dir')
     fprintf('%s: No directory: %s. Skipping.\n', mfilename,sprintf('%s',sectionDir))

--- a/code/SystemClasses/@bakingtray/tileLoad.m
+++ b/code/SystemClasses/@bakingtray/tileLoad.m
@@ -33,6 +33,7 @@ end
 %Exit gracefully if data directory is missing 
 param = readMetaData2Stitchit;
 sectionDir=fullfile(userConfig.subdir.rawDataDir, sprintf('%s-%04d',param.sample.ID,coords(1)));
+sectionProcessDir=fullfile(userConfig.subdir.preProcessDir, sprintf('%s-%04d',param.sample.ID,coords(1)));
 
 if ~exist(sectionDir,'dir')
     fprintf('%s: No directory: %s. Skipping.\n', mfilename,sprintf('%s',sectionDir))
@@ -182,7 +183,7 @@ end
 % is useful in the event that a drifting offset is creating problems. 
 % Can be used to deal with offset amplifiers for a wider dynamic range.
 if doSubtractOffset
-    tileStatsFname = fullfile(sectionDir, sprintf('tileStats_ch%.0f.mat', channel));
+    tileStatsFname = fullfile(sectionProcessDir, sprintf('tileStats_ch%.0f.mat', channel));
     if exist(tileStatsFname,'file')
         load(tileStatsFname)
         offsetMu = mean(tileStats.offsetMean(:)); %since all depths will have the same underlying value

--- a/code/preProcessTiles/private/calcAverageMatFiles.m
+++ b/code/preProcessTiles/private/calcAverageMatFiles.m
@@ -56,7 +56,7 @@ function calcAverageMatFiles(imStack,tileIndex,thisDirName,illumChans,tileStats)
         % We will get rid of *really* dim tiles by removing tiles with a mean lower than tileStats.emptyTileThresh
         % The following ensures that we choose reasonable numbers based on the amp offsets
         mu = squeeze(mean(mean(thisStack)));
-        lowVals = find(mu<tileStats.emptyTileThresh(thisChan,thisLayer));
+        lowVals = find(mu<tileStats{thisChan}.emptyTileThresh(thisLayer));
 
         %Fail gracefully if tile index is not complete
         if isempty(tileIndex{thisChan,thisLayer})
@@ -85,7 +85,7 @@ function calcAverageMatFiles(imStack,tileIndex,thisDirName,illumChans,tileStats)
         thisStack(:,:,lowVals)=[]; % <--- Tiles with low values deleted here
 
         % Apply the tile offset. (It will be zero if it was not calculated)
-        offsetMu = mean(tileStats.offsetMean(thisChan,:)); %since all depths will have the same underlying value
+        offsetMu = mean(tileStats{thisChan}.offsetMean(:)); %since all depths will have the same underlying value
         thisStack = thisStack - cast(offsetMu,class(thisStack));
 
 

--- a/code/preProcessTiles/private/writeTileStats.m
+++ b/code/preProcessTiles/private/writeTileStats.m
@@ -1,4 +1,4 @@
-function [tileStats,imStack]=writeTileStats(imStack,tileIndex,thisDirName,statsFile)
+function [tileStats, imStack]=writeTileStats(imStack,tileIndex,thisDirName,statsFile)
     % Writes a tile stats MAT file to each directory
     %
     % function [tileStats,imStack]=writeTileStats(imStack,tileIndex,thisDirName,statsFile)
@@ -9,8 +9,7 @@ function [tileStats,imStack]=writeTileStats(imStack,tileIndex,thisDirName,statsF
     % background tiles, etc. 
     %
     % Inputs
-    % imStack - A cell array of image stacks. The rows are channels and the
-    %           columns are optical sections.
+    % imStack - A cell array of image stacks. One column per optical section.
     % tileIndex - A cell array of tileIndex matrices.
     % thisDirName - a string defining the directory to which we will save the data
     % statsFile - string defining where to save the data.
@@ -29,83 +28,87 @@ function [tileStats,imStack]=writeTileStats(imStack,tileIndex,thisDirName,statsF
     tileStats.dirName=thisDirName;
     userConfig=readStitchItINI;
     M=readMetaData2Stitchit;
+    
+    if size(imStack, 1) > 1
+        error('Error: writeTileStats needs single channel imStack\n')
+    end
+    
 
-    for thisChan = 1:size(imStack,1) % Channels
-        for thisLayer = 1:size(imStack,2) % Optical sections
+    for thisLayer = 1:size(imStack,2) % Optical sections
 
-            if isempty(imStack{thisChan,thisLayer}), continue, end
+        if isempty(imStack{1,thisLayer}), continue, end
 
-            tileStats.tileIndex{thisChan,thisLayer}=tileIndex{thisChan,thisLayer}(:,1);
+        tileStats.tileIndex{1,thisLayer}=tileIndex{1,thisLayer}(:,1);
 
-            thisStack = imStack{thisChan,thisLayer};
-            mu = squeeze(mean(mean(thisStack)));
-            tileStats.mu{thisChan,thisLayer} = mu;
+        thisStack = imStack{1,thisLayer};
+        mu = squeeze(mean(mean(thisStack)));
+        tileStats.mu{1,thisLayer} = mu;
 
-            [mu,sortedInds] = sort(mu);
+        [mu,sortedInds] = sort(mu);
 
-            % Find the offset value using a mixture of Gaussians based on the dimmest tiles
-            % This is useful for some imaging systems only. For ScanImage it could be helpful
-            % but for systems that discard this offset it won't mean anything. So we don't 
-            % calculate this for systems where it won't help
-            tileStats.offsetMean(thisChan,thisLayer) = 0; % by default set to zero then over-write if the user asked for an offset
-            if userConfig.tile.doOffsetSubtraction
-                switch M.System.type
-                case 'bakingtray'
-                    proportionOfDimmestFramesToUse=0.1;
-                    nDimmestFrames = floor(length(sortedInds)*proportionOfDimmestFramesToUse);
+        % Find the offset value using a mixture of Gaussians based on the dimmest tiles
+        % This is useful for some imaging systems only. For ScanImage it could be helpful
+        % but for systems that discard this offset it won't mean anything. So we don't 
+        % calculate this for systems where it won't help
+        tileStats.offsetMean(1,thisLayer) = 0; % by default set to zero then over-write if the user asked for an offset
+        if userConfig.tile.doOffsetSubtraction
+            switch M.System.type
+            case 'bakingtray'
+                proportionOfDimmestFramesToUse=0.1;
+                nDimmestFrames = floor(length(sortedInds)*proportionOfDimmestFramesToUse);
 
-                    if nDimmestFrames==0;
-                        nDimmestFrames=1;
-                    end
-
-                    dimFrames=thisStack(:,:,sortedInds(1:nDimmestFrames));
-                    options = statset('MaxIter', 1000);
-                    Gm=fitgmdist(single(dimFrames(1:100:end)'),2, 'SharedCovariance', true, 'Options', options); % Mixture of 2 Gaussians
-                    if Gm.Converged
-                        [~,maxPropInd]=max(Gm.ComponentProportion);
-                        tileStats.offsetMean(thisChan,thisLayer) = Gm.mu(maxPropInd);
-                    else
-                        % It's already filled with a zero
-                    end
-                end % switch
-            end %if userConfig.tile.doOffsetSubtraction
-
-
-
-
-
-            % Create a threshold that should capture most of the empty tiles.
-            % This will allow us to exclude most of them without having to resort
-            % to fixed thresholds.
-            % TODO: Possibly we can use the model fit from above to help with this, 
-            %       but I'm not sure how.
-
-            bottomFivePercent = mu(1:round(length(mu)*0.05));
-            if std(bottomFivePercent)>0.6
-                fprintf('%s - Empty tile threshold not trustworthy (STD=%0.2f), setting it to the mean of dimmest tile.\n',...
-                    mfilename, std(bottomFivePercent))
-                emptyTileThresh=mu(1);
-            else
-                STDvals=zeros(size(mu));
-                for ii=1:length(mu)
-                    STDvals(ii)=std(mu(1:ii));
+                if nDimmestFrames==0
+                    nDimmestFrames=1;
                 end
-                f=find(STDvals<0.085); %A threshold that we'll consider to represent the empty tiles
 
-                emptyTileThresh=mu(f(end))*1.01;
+                dimFrames=thisStack(:,:,sortedInds(1:nDimmestFrames));
+                options = statset('MaxIter', 1000);
+                Gm=fitgmdist(single(dimFrames(1:100:end)'),2, 'SharedCovariance', true, 'Options', options); % Mixture of 2 Gaussians
+                if Gm.Converged
+                    [~,maxPropInd]=max(Gm.ComponentProportion);
+                    tileStats.offsetMean(1,thisLayer) = Gm.mu(maxPropInd);
+                else
+                    % It's already filled with a zero
+                end
+            end % switch
+        end %if userConfig.tile.doOffsetSubtraction
+
+
+
+
+
+        % Create a threshold that should capture most of the empty tiles.
+        % This will allow us to exclude most of them without having to resort
+        % to fixed thresholds.
+        % TODO: Possibly we can use the model fit from above to help with this, 
+        %       but I'm not sure how.
+
+        bottomFivePercent = mu(1:round(length(mu)*0.05));
+        if std(bottomFivePercent)>0.6
+            fprintf('%s - Empty tile threshold not trustworthy (STD=%0.2f), setting it to the mean of dimmest tile.\n',...
+                mfilename, std(bottomFivePercent))
+            emptyTileThresh=mu(1);
+        else
+            STDvals=zeros(size(mu));
+            for ii=1:length(mu)
+                STDvals(ii)=std(mu(1:ii));
             end
+            f=find(STDvals<0.085); %A threshold that we'll consider to represent the empty tiles
 
-            tileStats.emptyTileThresh(thisChan,thisLayer)=emptyTileThresh;
+            emptyTileThresh=mu(f(end))*1.01;
+        end
 
-            %Store a histogram for each tile
-            tileStats.histogram{thisChan,thisLayer} = cell(1,size(thisStack,3));
-            for thisTile = 1:size(thisStack,3)
-                tmp = single(thisStack(:,:,thisTile));
-                [n,x] = hist(tmp(1:10:end), 1000); %every 10th for speed, even though it means we'll miss the extreme values. 
-                tileStats.histogram{thisChan,thisLayer}{thisTile} = [n;x];
-            end
+        tileStats.emptyTileThresh(1,thisLayer)=emptyTileThresh;
+
+        %Store a histogram for each tile
+        tileStats.histogram{1,thisLayer} = cell(1,size(thisStack,3));
+        for thisTile = 1:size(thisStack,3)
+            tmp = single(thisStack(:,:,thisTile));
+            [n,x] = hist(tmp(1:10:end), 1000); %every 10th for speed, even though it means we'll miss the extreme values. 
+            tileStats.histogram{1,thisLayer}{thisTile} = [n;x];
         end
     end
+    
     save(statsFile,'tileStats')
 
     % If a second output (the offset-corrected image stack) is requested, then create this, 
@@ -115,11 +118,11 @@ function [tileStats,imStack]=writeTileStats(imStack,tileIndex,thisDirName,statsF
     end
 
     % Apply the tile offset. (It will be zero if it was not calculated)
-    for thisChan = 1:size(imStack,1) % Channels
-        offsetMu = mean(tileStats.offsetMean(thisChan,:)); %since all depths will have the same underlying value
-        offsetMu = cast(offsetMu,class(imStack{1,1}));
 
-        for thisLayer = 1:size(imStack,2) % Optical sections
-            imStack{thisChan,thisLayer} = imStack{thisChan,thisLayer} - offsetMu;
-        end
+    offsetMu = mean(tileStats.offsetMean(1,:)); %since all depths will have the same underlying value
+    offsetMu = cast(offsetMu,class(imStack{1,1}));
+
+    for thisLayer = 1:size(imStack,2) % Optical sections
+        imStack{1,thisLayer} = imStack{1,thisLayer} - offsetMu;
     end
+    


### PR DESCRIPTION
Now every channel has its own tileStats. Update all the functions
using tileStats except loadAllTileStatsFiles.

TODO:
- check that loadAllTileStatsFiles is never called. If it is
called, look if I should recreate an old style common tileStats
as output or update downstream function
- make illumCorr and comboCorr smarter, let them check if all the
files exist and load only channels needed