### PR TITLE
Allow vector as input argument for stitchSize

### DIFF
--- a/code/stitching/stitchSection.m
+++ b/code/stitching/stitchSection.m
@@ -91,7 +91,7 @@ end
 %Parse optional arguments
 params = inputParser;
 params.CaseSensitive = false;
-params.addParamValue('stitchedSize', 100, @(x) isnumeric(x) && isscalar(x));
+params.addParamValue('stitchedSize', 100, @(x) isnumeric(x));
 params.addParamValue('overwrite', false, @(x) islogical(x) || x==0 || x==1);
 params.addParamValue('chessboard', false, @(x) islogical(x) || x==0 || x==1);
 params.parse(varargin{:});


### PR DESCRIPTION
The input parsing function was too stringent for `stitchSize`. Just check if it's numeric and allow vectors.