### PR TITLE
Simpler preProcessTiles argument and bugfix in syncAndCrunch

### DIFF
--- a/code/preProcessTiles/preProcessTiles.m
+++ b/code/preProcessTiles/preProcessTiles.m
@@ -38,10 +38,9 @@ function varargout=preProcessTiles(sectionsToProcess,channelsToProcess, varargin
 %    these section directories AND we over-write existing coefficient files in all 
 %    channels.
 %
-% - channelsToProcess - By default all channels are used to
-% generate tileStats files. This can be modified here. One top of
-% the channels listed in `channelsToProcess`, channels in
-% `combCorChans` and/or `illumChans` will be processed as described below
+% - channelsToProcess - If is empty (default), all channels are
+% used to  generate tileStats files. If 0, only channels from
+% `combCorChans` and/or `illumChans` will be processed.
 %
 %
 % INPUTS (optional param/value pairs)
@@ -105,8 +104,8 @@ if nargin<1 || isempty(sectionsToProcess)
 end
 
 
-if nargin<2 || isempty(channelsToProcess)
-    channelsToProcess=0;
+if nargin<2
+    channelsToProcess=[];
 end
 
 params = inputParser;
@@ -172,9 +171,8 @@ tic
 
 %Figure out which channels we are to load on each pass through the
 %loop
-if channelsToProcess == 0
+if isempty(channelsToProcess)
     channelsToProcess = [param.sample.activeChannels{:}];
-    % TODO that works for bakingTray check for tissuecyte?
 end
 
 illumChans=illumChans(:)'; %ensure it's a row vector

--- a/code/processDuringAcquistion/syncAndCrunch.m
+++ b/code/processDuringAcquistion/syncAndCrunch.m
@@ -328,7 +328,8 @@ while 1
 
 
 
-  analysesPerformed = preProcessTiles(0,0,'combCorChans', combCorChans, 'illumChans'); %PRE-PROCESS TILES
+  analysesPerformed = preProcessTiles(0,0,'combCorChans', combCorChans, ...
+                                      'illumChans', illumChans); %PRE-PROCESS TILES
 
 
   if isempty(analysesPerformed)


### PR DESCRIPTION
Correct a small forgotten argument in syncAndCrunch

Change preProcessTiles behaviour for channelsToProcess: if isempty
then process all the channels but if is 0 then process only channels
in combCorChan or illumChan

TODO: Put channelsToProcess as named optional argument?