### PR TITLE
Correct potentially bogus warning in openTiff

### DIFF
--- a/code/+stitchit/+tools/openTiff.m
+++ b/code/+stitchit/+tools/openTiff.m
@@ -161,9 +161,16 @@ function [I,imInfo] = openTiff(fileName, regionSpec, downSample, methodFlag)
   end
 
   %Check if the image is the expected size. If not, there is likely corruption
-  if size(I,1) ~= imInfo.Height || size(I,2) ~= imInfo.Width
-    fprintf('\n\n ** Assembled image is of size %d by %d. Expected size is %d by %d. Image %s is probably garbled.\n', ...
-      size(I,1), size(I,2), imInfo.Height, imInfo.Width, fileName)
+  if ~doCrop
+      if size(I,1) ~= imInfo.Height || size(I,2) ~= imInfo.Width
+          fprintf('\n\n ** Assembled image is of size %d by %d. Expected size is %d by %d. Image %s is probably garbled.\n', ...
+              size(I,1), size(I,2), imInfo.Height, imInfo.Width, fileName)
+      end
+  else
+      if size(I,1) ~= regionSpec(4) || size(I,2) ~= regionSpec(3)
+          fprintf('\n\n ** Assembled image is of size %d by %d. Expected size is %d by %d. Image %s is probably garbled.\n', ...
+              size(I,1), size(I,2), regionSpec(4), regionSpec(3), fileName)
+      end
   end
 
 end %openTiff


### PR DESCRIPTION
openTiff checks that the size of the output image correspond to the size of the image read from the image header. It does it even if the user specify regionSpec and doesn't load the whole image.
Do not check using the header if the image is cropped. 
Still check using the regionSpec argument but I guess that there would be a crash
before if that was wrong

@raacampbell is that the correct behaviour? 