### PR TITLE
Update examples in documentation of preProcessTiles

### DIFF
--- a/code/preProcessTiles/preProcessTiles.m
+++ b/code/preProcessTiles/preProcessTiles.m
@@ -70,19 +70,19 @@ function varargout=preProcessTiles(sectionsToProcess, varargin)
 % One
 % Process sections [1,1] and [90,5] (i.e. physical section 90, optical section 5)
 % If these already exist, they are re-processed. Process only channel 1 illumination correction.
-% preProcessTiles([1,1;90,5],0,'illumChans',1)
+% preProcessTiles([1,1;90,5], 'illumChans',1)
 %
 % Two
 % Make tileStats only for physical sections 10 to 20 of channels 1 and 2
-% preProcessTiles(1:20,1:2)
+% preProcessTiles(1:20,'channelsToProcess', 1:2)
 %
 % Three
 % Process all illumination correction data not already done for channel 1.
-% preProcessTiles([],0,'illumChans',1)
+% preProcessTiles([],'illumChans',1)
 %
 % Four
 % re-precess everything for channel 1 illumination correction.
-% preProcessTiles(-1,0,'illumChans',1)
+% preProcessTiles(-1, 'illumChans',1)
 %
 %
 %


### PR DESCRIPTION
Just remove the now optional 'channelsToProcess' argument from examples